### PR TITLE
[Fix bug] Fix submodule for RBDyn/Benchmark submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,5 @@
+[submodule "benchmark"]
+	path = RBDyn/tests/benchmark
+	url = https://github.com/google/benchmark
+	branch = 1d088a389947ef14043d14c8de90629cf96b8b66
+

--- a/RBDyn/.gitmodules
+++ b/RBDyn/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "benchmark"]
-	path = tests/benchmark
-	url = https://github.com/google/benchmark


### PR DESCRIPTION
Thank you very much for your work. While we are cloning and installing this [work](https://github.com/ahundt/grl), we faced some problems with cloning this repo.

When you clone the repo, the benchmark repo seems not correctly cloned. The solution that worked is to copy .gitsubmodules to the root of the repo and point to the corresponding branch with the commit of RBDyn.